### PR TITLE
Remove db from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.user
 *.userosscache
 *.sln.docstates
-*.db
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
The DB being in the gitignore causes issues when cloning the repo for the first time. It will continued being tracked until I find a better solution.