### PR TITLE
Update Basestation_Software.Web.csproj

### DIFF
--- a/Basestation_Software.Web/Basestation_Software.Web.csproj
+++ b/Basestation_Software.Web/Basestation_Software.Web.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
     <PackageReference Include="OpenCvSharp4.runtime.ubuntu.22.04-x64" Version="4.6.0-SNAPSHOT" />
-    <PackageReference Include="RoveComm" Version="1.0.2" />
+    <PackageReference Include="RoveComm" Version="*" />
     <PackageReference Include="ScottPlot" Version="5.0.40" />
     <PackageReference Include="ScottPlot.Blazor" Version="5.0.39" />
     <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />


### PR DESCRIPTION
RoveComm package reference now always references the most recent version.