### PR TITLE
Feature/autonomy-monitor

### DIFF
--- a/Basestation_Software.Web/Basestation_Software.Web.csproj
+++ b/Basestation_Software.Web/Basestation_Software.Web.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
     <PackageReference Include="OpenCvSharp4.runtime.ubuntu.22.04-x64" Version="4.6.0-SNAPSHOT" />
-    <PackageReference Include="RoveComm" Version="*" />
+    <PackageReference Include="RoveComm" Version="1.0.11" />
     <PackageReference Include="ScottPlot" Version="5.0.40" />
     <PackageReference Include="ScottPlot.Blazor" Version="5.0.39" />
     <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />

--- a/Basestation_Software.Web/Basestation_Software.Web.csproj
+++ b/Basestation_Software.Web/Basestation_Software.Web.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
     <PackageReference Include="OpenCvSharp4.runtime.ubuntu.22.04-x64" Version="4.6.0-SNAPSHOT" />
-    <PackageReference Include="RoveComm" Version="1.0.11" />
+    <PackageReference Include="RoveComm" Version="1.0.13" />
     <PackageReference Include="ScottPlot" Version="5.0.40" />
     <PackageReference Include="ScottPlot.Blazor" Version="5.0.39" />
     <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />

--- a/Basestation_Software.Web/Core/Components/AutoMonitor.razor
+++ b/Basestation_Software.Web/Core/Components/AutoMonitor.razor
@@ -1,19 +1,26 @@
 ﻿@inject RoveCommService _RoveCommService
 
+<style>
+    p {
+    margin-bottom: 0;
+    }
+</style>
+
 <div class="card h-100">
     <div class="card-header">
         <h3>Autonomy Monitor</h3>
     </div>
     <div class="card-body">
         <div style="display: grid; grid-template-columns: auto auto;" class="gap-2">
-        @for (int i = 0; i < _threadNames.Length; i++)
-        {
-            var _i = i;
-            <div class="d-flex rounded p-2 justify-content-center align-content-center bg-body-secondary mb-2 gap-1">
-                <p>@_threadNames[_i] FPS:</p>
-                <p>@_fpsValues[_i]</p>
-            </div>
-        }
+            @for (int i = 0; i < _threadNames.Length; i++)
+            {
+                var _i = i;
+                <div class="d-flex flex-column rounded p-2 bg-body-secondary justify-content-center align-content-center text-center">
+                    <p>@_threadNames[_i]</p>
+                    <p class="font-monospace fs-3"><b>@_fpsValues[_i] FPS</b></p>
+                    <hr style="border-color: color-mix(in oklab, green @(Math.Min(_fpsValues[_i], 60)/60f * 100)%, red) !important" class="border border-4 opacity-50 rounded-2" />
+                </div>
+            }
         </div>
     </div>
 </div>
@@ -22,23 +29,29 @@
     private List<uint> _fpsValues = new(new uint[11]);
     // i will add enums to rovecomm soon :(
     private string[] _threadNames = [
-        "MainProcess",
-        "MainCam",
-        "LeftCam",
-        "RightCam",
-        "GroundCam",
-        "MainDetector",
-        "LeftDetector",
-        "RightDetector",
-        "StateMachine",
-        "RoveCommUDP",
-        "RoveCommTCP"
+        "Main Process",
+    "Main Cam",
+    "Left Cam",
+    "Right Cam",
+    "Ground Cam",
+    "Main Detector",
+    "Left Detector",
+    "Right Detector",
+    "State Machine",
+    "RoveComm UDP",
+    "RoveComm TCP"
     ];
+
     protected override async Task OnInitializedAsync()
     {
         _RoveCommService.On<uint>("Autonomy", "ThreadFPS", async (packet) =>
         {
             _fpsValues[(int)packet.Data[0]] = packet.Data[1];
+            // low fps warning
+            if (packet.Data[1] < 10)
+            {
+                _ToastService.ShowWarning(string.Format("Autonomy Thread \"{0}\" is running at {1} FPS!", _threadNames[(int)packet.Data[0]], packet.Data[1]));
+            }
             await InvokeAsync(StateHasChanged);
         });
     }

--- a/Basestation_Software.Web/Core/Components/AutoMonitor.razor
+++ b/Basestation_Software.Web/Core/Components/AutoMonitor.razor
@@ -26,21 +26,8 @@
 </div>
 
 @code {
-    private List<uint> _fpsValues = new(new uint[11]);
-    // i will add enums to rovecomm soon :(
-    private string[] _threadNames = [
-        "Main Process",
-    "Main Cam",
-    "Left Cam",
-    "Right Cam",
-    "Ground Cam",
-    "Main Detector",
-    "Left Detector",
-    "Right Detector",
-    "State Machine",
-    "RoveComm UDP",
-    "RoveComm TCP"
-    ];
+    private uint[]_fpsValues = new uint[11];
+    private string[] _threadNames = Enum.GetNames(typeof(RoveComm.Boards.Autonomy.AUTONOMYTHREADS));
 
     protected override async Task OnInitializedAsync()
     {

--- a/Basestation_Software.Web/Core/Components/AutoMonitor.razor
+++ b/Basestation_Software.Web/Core/Components/AutoMonitor.razor
@@ -1,0 +1,45 @@
+﻿@inject RoveCommService _RoveCommService
+
+<div class="card h-100">
+    <div class="card-header">
+        <h3>Autonomy Monitor</h3>
+    </div>
+    <div class="card-body">
+        <div style="display: grid; grid-template-columns: auto auto;" class="gap-2">
+        @for (int i = 0; i < _threadNames.Length; i++)
+        {
+            var _i = i;
+            <div class="d-flex rounded p-2 justify-content-center align-content-center bg-body-secondary mb-2 gap-1">
+                <p>@_threadNames[_i] FPS:</p>
+                <p>@_fpsValues[_i]</p>
+            </div>
+        }
+        </div>
+    </div>
+</div>
+
+@code {
+    private List<uint> _fpsValues = new(new uint[11]);
+    // i will add enums to rovecomm soon :(
+    private string[] _threadNames = [
+        "MainProcess",
+        "MainCam",
+        "LeftCam",
+        "RightCam",
+        "GroundCam",
+        "MainDetector",
+        "LeftDetector",
+        "RightDetector",
+        "StateMachine",
+        "RoveCommUDP",
+        "RoveCommTCP"
+    ];
+    protected override async Task OnInitializedAsync()
+    {
+        _RoveCommService.On<uint>("Autonomy", "ThreadFPS", async (packet) =>
+        {
+            _fpsValues[(int)packet.Data[0]] = packet.Data[1];
+            await InvokeAsync(StateHasChanged);
+        });
+    }
+}


### PR DESCRIPTION
Implements a component that displays FPS telemetry packets received from Autonomy. Shows a toast notification if received FPS is below 10. 60 FPS is used as the "max" value for the status color.
Packet Tester script used to verify functionality: 
```
500 Autonomy ThreadFPS 0 60
500 Autonomy ThreadFPS 1 50
500 Autonomy ThreadFPS 2 40
500 Autonomy ThreadFPS 3 30
500 Autonomy ThreadFPS 4 20
500 Autonomy ThreadFPS 5 10
500 Autonomy ThreadFPS 6 2
500 Autonomy ThreadFPS 7 1
500 Autonomy ThreadFPS 8 120
500 Autonomy ThreadFPS 8 34
500 Autonomy ThreadFPS 9 999
```
![auto-monitor-component](https://github.com/user-attachments/assets/18f147b7-57da-4f30-abf9-f41769da0764)
![auto-monitor-toast](https://github.com/user-attachments/assets/58ea3ffe-3b06-4a81-bfed-955faa99ce1f)

