### PR TITLE
Replace rovecomm nuget package with git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "RoveComm_CSharp"]
+	path = RoveComm_CSharp
+	url = https://github.com/MissouriMRDT/RoveComm_CSharp.git

--- a/Basestation_Software.Web/Basestation_Software.Web.csproj
+++ b/Basestation_Software.Web/Basestation_Software.Web.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Basestation_Software.Models\Basestation_Software.Models.csproj" />
+    <ProjectReference Include="..\RoveComm_CSharp\RoveComm\RoveComm.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -13,7 +14,6 @@
     </PackageReference>
     <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
     <PackageReference Include="OpenCvSharp4.runtime.ubuntu.22.04-x64" Version="4.6.0-SNAPSHOT" />
-    <PackageReference Include="RoveComm" Version="*" />
     <PackageReference Include="ScottPlot" Version="5.0.40" />
     <PackageReference Include="ScottPlot.Blazor" Version="5.0.39" />
     <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" />

--- a/Basestation_Software.sln
+++ b/Basestation_Software.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Basestation_Software.Models
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Basestation_Software.Api", "Basestation_Software.Api\Basestation_Software.Api.csproj", "{1E94F4E9-944B-4373-96E8-2B15C550A4AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoveComm", "RoveComm_CSharp\RoveComm\RoveComm.csproj", "{1D99F6EF-D303-4454-BC2C-B7D847D96618}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{1E94F4E9-944B-4373-96E8-2B15C550A4AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E94F4E9-944B-4373-96E8-2B15C550A4AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E94F4E9-944B-4373-96E8-2B15C550A4AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D99F6EF-D303-4454-BC2C-B7D847D96618}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D99F6EF-D303-4454-BC2C-B7D847D96618}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D99F6EF-D303-4454-BC2C-B7D847D96618}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D99F6EF-D303-4454-BC2C-B7D847D96618}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Replace Rovecomm nuget package with the more typical git submodule to make rovecomm updates easier and local Rovecomm hotfixes possible.