### PR TITLE
Initialize/Setup data.db if it does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ bin/
 [Oo]bj/
 [Ll]og/
 
+# Ignore database files
+*.db
+/Basestation_Software.Api/Data/
 
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
@@ -265,5 +268,3 @@ __pycache__/
 *.pyc
 /.vs/ProjectEvaluation/basestation_software.metadata.v7.bin
 /.vs/ProjectEvaluation/basestation_software.projects.v7.bin
-
-/Basestation_Software.Api/Data/*

--- a/Basestation_Software.Api/Entities/REDDatabase.cs
+++ b/Basestation_Software.Api/Entities/REDDatabase.cs
@@ -3,6 +3,8 @@ using Basestation_Software.Models.Config;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using System.Xml.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Basestation_Software.Api.Entities;
 
@@ -18,6 +20,16 @@ public class REDDatabase : DbContext
     {
         // Assign member variables.
         Configuration = configuration;
+
+        // Attempt to form missing tables in data.db
+        try
+        {
+            (Database.GetService<IDatabaseCreator>() as RelationalDatabaseCreator).CreateTables();
+        }
+        catch
+        {
+            // CreateTables throws error if table already exists but we don't care
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Changes the API project's database initialization to create data.db or any tables if they are missing. Also changes the gitignore to remove data.db from version control as it is no longer needed to run Basestation Software locally.