### PR TITLE
Implement multiple gripper functionality (and update manifest)

### DIFF
--- a/Basestation_Software.Web/Core/Components/ArmControls.razor
+++ b/Basestation_Software.Web/Core/Components/ArmControls.razor
@@ -6,27 +6,27 @@
 
 <style>
     p {
-        width: 110px;
-        text-align: right;
-        margin-bottom: 0;
+    width: 110px;
+    text-align: right;
+    margin-bottom: 0;
     }
 
     .jointBox {
-        display: flex;
-        column-gap: 0.6rem;
-        row-gap: 0.1rem;
-        justify-items: center;
-        flex: 0 1 160px;
-        flex-wrap:wrap;
-        border-radius: 10px;
-        background-color: var(--bs-secondary-bg);
-        margin: 0.2rem;
-        padding: 0.3rem;
+    display: flex;
+    column-gap: 0.6rem;
+    row-gap: 0.1rem;
+    justify-items: center;
+    flex: 0 1 160px;
+    flex-wrap:wrap;
+    border-radius: 10px;
+    background-color: var(--bs-secondary-bg);
+    margin: 0.2rem;
+    padding: 0.3rem;
     }
 
     .break {
-        flex-basis: 100%;
-        height: 0;
+    flex-basis: 100%;
+    height: 0;
     }
 </style>
 
@@ -56,6 +56,10 @@
         <div style="display:flex; gap:0.6rem;">
             <RadzenCheckBox TValue="bool" Value="true" bind-Value=@UpdateIndividualJoints />
             <p style="width: auto; text-align: left">Control Joints Individually</p>
+        </div>
+        <div style="display:flex; gap:0.6rem;">
+            <RadzenCheckBox TValue="bool" Value="false" bind-Value=@isAlternateGripper />
+            <p style="width: auto; text-align: left">Drive Alternate Gripper</p>
         </div>
 
         <div class="rounded p-2 justify-items-center bg-body-secondary mb-2">
@@ -234,18 +238,18 @@
     {
         double[] gamepadInputs = [
             gamepad.Axes[0],
-            gamepad.Axes[1],
-            gamepad.Axes[2],
-            gamepad.Axes[3],
-            gamepad.Buttons[0].Value - gamepad.Buttons[1].Value,
-            gamepad.Buttons[2].Value - gamepad.Buttons[3].Value,
-            gamepad.Buttons[4].Value - gamepad.Buttons[5].Value,
-            gamepad.Axes[4] - gamepad.Axes[5],
-            gamepad.Buttons[14].Value - gamepad.Buttons[15].Value,
-            gamepad.Buttons[12].Value - gamepad.Buttons[13].Value,
-            gamepad.Buttons[9].Value - gamepad.Buttons[8].Value,
-            0d,
-        ];
+        gamepad.Axes[1],
+        gamepad.Axes[2],
+        gamepad.Axes[3],
+        gamepad.Buttons[0].Value - gamepad.Buttons[1].Value,
+        gamepad.Buttons[2].Value - gamepad.Buttons[3].Value,
+        gamepad.Buttons[4].Value - gamepad.Buttons[5].Value,
+        gamepad.Axes[4] - gamepad.Axes[5],
+        gamepad.Buttons[14].Value - gamepad.Buttons[15].Value,
+        gamepad.Buttons[12].Value - gamepad.Buttons[13].Value,
+        gamepad.Buttons[9].Value - gamepad.Buttons[8].Value,
+        0d,
+    ];
 
         return gamepadInputs;
     }
@@ -259,6 +263,7 @@
     private bool LastProcessGamepadInputOK = false;
     private double DeadZone = 0.5;
     bool UpdateIndividualJoints = true;
+    private bool isAlternateGripper = false;
     List<bool> isJointInverted = [false, false, false, false, false, false];
     // in order of joint enum
     // List<int> jointInputBinds = [0, 1, 2, 3, 4, 5];
@@ -416,7 +421,7 @@
                         if (!OutputDisabled) _ = _RoveCommService.SendAsync<float>("Arm", "IncrementIndividualTargetAngles", Array.ConvertAll(jointInputs, j => (float)j).ToList());
                     }
 
-                    if (!OutputDisabled) _ = Task.Run(() => _RoveCommService.SendAsync<short>("Arm", "SetGripperSpeed", [(short)(inputValues[(int)gripperBind] * _ArmSpeedState.ArmSpeeds["Gripper"] * 1000f * (isGripperInverted ? -1 : 1))]));
+                    if (!OutputDisabled) _ =  _RoveCommService.SendAsync<short>("Arm", "SetGripperSpeed", [(short)(inputValues[(int)gripperBind] * _ArmSpeedState.ArmSpeeds["Gripper"] * 1000f * (isGripperInverted ? -1 : 1)), (short)(isAlternateGripper ? 1 : 0)]);
                     gripperMeterValue = inputValues[(int)gripperBind];
                     laserMeterValue = inputValues[(int)laserBind];
                     solMeterValue = inputValues[(int)solBind];


### PR DESCRIPTION
This PR implements support for the two grippers now on the arm via a checkbox. It also updates the manifest to a version that also supports multiple grippers.

![image](https://github.com/user-attachments/assets/c082a8ec-621b-45fb-b0fc-72bb832dce67)
