### PR TITLE
Fixed component height

### DIFF
--- a/Basestation_Software.Web/Core/Layout/MainLayout.razor
+++ b/Basestation_Software.Web/Core/Layout/MainLayout.razor
@@ -16,7 +16,7 @@
     #layout-grid {
     display: grid;
     grid-template-columns: repeat(@Config_.Columns, 1fr);
-    grid-template-rows: repeat(@Config_.Columns, 1fr);
+    grid-template-rows: repeat(@Config_.Columns, 32px);
     /* width: @($"{Config_.Width}vw"); */
     height: @($"{Config_.Height}vh");
     padding-top: 75px;

--- a/Basestation_Software.Web/Core/Layout/MainLayout.razor
+++ b/Basestation_Software.Web/Core/Layout/MainLayout.razor
@@ -17,7 +17,7 @@
     display: grid;
     grid-template-columns: repeat(@Config_.Columns, 1fr);
     grid-template-rows: repeat(@Config_.Columns, 1fr);
-    width: @($"{Config_.Width}vw");
+    /* width: @($"{Config_.Width}vw"); */
     height: @($"{Config_.Height}vh");
     padding-top: 75px;
     gap: 0.5rem;

--- a/Basestation_Software.Web/wwwroot/bootstrap-ext.css
+++ b/Basestation_Software.Web/wwwroot/bootstrap-ext.css
@@ -1,6 +1,11 @@
 .card-header {
-    background-color: #9a0000; 
+    background-color: #9a0020;
     color: white;
+}
+
+.card {
+    border: 1px solid #9a0020;
+    transition: .25s;
 }
 
 .card-header h3 {
@@ -23,9 +28,4 @@
 .card:hover {
     box-shadow: 5px 5px 0px rgba(209, 3, 3, 0.692);
 /*    transform:scale(1.004);*/
-}
-
-.card {
-    border:1px solid black;
-    transition:.25s;
 }


### PR DESCRIPTION
Changes the height of cells in the component grid to be a fixed 32px instead of being based on viewport height. This means that loading layouts made meant for vertical monitors will not look squished on horizontal ones, instead being a scroll-able page. Layouts made for 1080x1920 monitors will not look different after this change. Also matches the component outline to the header color.